### PR TITLE
Add 'format" para into datetime_to_float

### DIFF
--- a/transitionMatrix/utils/converters.py
+++ b/transitionMatrix/utils/converters.py
@@ -38,7 +38,7 @@ def frame_to_array(dataframe):
     return entity_id, event_time, entity_state
 
 
-def datetime_to_float(dataframe, time_column='Time'):
+def datetime_to_float(dataframe, time_column='Time', format=None):
     """datetime_to_float() converts dates from string format to the canonical float format
 
     :param time_column: the column label of the observation times
@@ -51,7 +51,7 @@ def datetime_to_float(dataframe, time_column='Time'):
     """
 
     dataframe[time_column] = dataframe[time_column].apply(
-        lambda x: (pd.to_datetime(x)))
+        lambda x: (pd.to_datetime(x, format=format)))
 
     # Find the start and end dates of the sample
     start_date = dataframe[time_column].min()


### PR DESCRIPTION
Add 'format" para into datetime_to_float which will uplift robustness against various kinds of input data, such as 'YYYYMM'